### PR TITLE
fix forM_ had arguments reversed

### DIFF
--- a/src/Data/Primitive/Contiguous.hs
+++ b/src/Data/Primitive/Contiguous.hs
@@ -1498,10 +1498,10 @@ forM = flip mapM
 -- | 'forM_' is 'mapM_' with its arguments flipped. For a version that
 --   doesn't ignore its results, see 'forM'.
 forM_ :: (Contiguous arr, Element arr a, Element arr b, Applicative f)
-  => (a -> f b)
-  -> arr a
+  => arr a
+  -> (a -> f b)
   -> f ()
-forM_ = traverse_
+forM_ = flip traverse_
 {-# inline forM_ #-}
 
 -- | Evaluate each action in the structure from left to right


### PR DESCRIPTION
I'm not sure whether to bump the version to 0.6.0 because it's a breaking change, or 0.5.3 since `forM_` being this useless was unintended in the api and nobody would've used it anyway. Either way, I decided to separate fix from release schedule.