### PR TITLE
Bump up 'base' lower bound to GHC 8.10

### DIFF
--- a/contiguous.cabal
+++ b/contiguous.cabal
@@ -29,7 +29,7 @@ library
     Data.Primitive.Contiguous.Shim
   hs-source-dirs: src
   build-depends:
-      base >=4.11.1.0 && <5
+      base >=4.14 && <5
     , primitive >= 0.7.2 && < 0.8
     , primitive-unlifted >= 0.1 && < 0.2
     , deepseq >= 1.4


### PR DESCRIPTION
I see that the `contiguous` package uses the `UnliftedNewtypes` extension. This extension appeared only in GHC 8.10 according to [GHC User Guide](https://downloads.haskell.org/ghc/latest/docs/html/users_guide/exts/primitives.html?highlight=unliftednewtypes#extension-UnliftedNewtypes). Build tools detect supported GHC versions from the `base` version and `base` is a boot library. So I'm increasing the lower bound to reflect the state of supported GHC versions more precisely.

Current behaviour causes failures like this one:

* https://github.com/co-log/co-log-benchmarks/pull/1