### PR TITLE
build on ghc 9.2 (once primitive-unlifted has also updated)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+0.6.1.1: [2021.XX.XX]
+---------------------
+* Allow building with GHC 9.2.1
+
 0.6.0: [2021.XX.XX]
 -------------------
 * Add `Slice`, `MutableSlice`.

--- a/contiguous.cabal
+++ b/contiguous.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 name: contiguous
-version: 0.6.1
+version: 0.6.1.1
 homepage: https://github.com/andrewthad/contiguous
 bug-reports: https://github.com/andrewthad/contiguous/issues
 author: Andrew Martin
@@ -31,7 +31,7 @@ library
   build-depends:
       base >=4.14 && <5
     , primitive >= 0.7.2 && < 0.8
-    , primitive-unlifted >= 0.1 && < 0.2
+    , primitive-unlifted >= 0.1.3.1 && < 0.2
     , deepseq >= 1.4
     , run-st >= 0.1.1
   default-language: Haskell2010


### PR DESCRIPTION
With this change I'm able to build in GHC 9.2.1, 9.0.1, and 8.10.7, provided I'm building against a similarly updated version of `primitive-unlifted`. I've submitted a request for such an update: https://github.com/haskell-primitive/primitive-unlifted/issues/26

Once there is such a release (say `0.1.3.1`), I'm not quite sure whether it's better to have a release of `contiguous` that uses CPP like this to work across GHC versions, but would then presumably need a weird dependency constraint like `base < 4.16 || primitive-unlifted >= 0.1.3.1`. Or to just make a non-CPP version that only works on GHC 9.2, and revise the bounds on the previous versions to `base < 4.16`.