### PR TITLE
build with primitive 0.8

### DIFF
--- a/contiguous.cabal
+++ b/contiguous.cabal
@@ -30,7 +30,7 @@ library
   hs-source-dirs: src
   build-depends:
       base >=4.14 && <5
-    , primitive >= 0.7.2 && < 0.8
+    , primitive >= 0.7.2 && < 0.9
     , primitive-unlifted >= 0.1.3.1 && < 0.2
     , deepseq >= 1.4
     , run-st >= 0.1.1


### PR DESCRIPTION
```
❯ cabal build --constraint="primitive == 0.8.0.0" --allow-newer=primitive-unlifted:primitive --allow-newer=run-st:primitive
Resolving dependencies...
Build profile: -w ghc-9.4.4 -O1
In order, the following will be built (use -v for more details):
 - contiguous-0.6.3.0 (lib) (first run)
Configuring library for contiguous-0.6.3.0..
Preprocessing library for contiguous-0.6.3.0..
Building library for contiguous-0.6.3.0..
[1 of 3] Compiling Data.Primitive.Contiguous.Shim ( src/Data/Primitive/Contiguous/Shim.hs, /home/chessai/haskell/contiguous/dist-newstyle/build/x86_64-linux/ghc-9.4.4/contiguous-0.6.3.0/build/Data/Primitive/Contiguous/Shim.o, /home/chessai/haskell/contiguous/dist-newstyle/build/x86_64-linux/ghc-9.4.4/contiguous-0.6.3.0/build/Data/Primitive/Contiguous/Shim.dyn_o )
[2 of 3] Compiling Data.Primitive.Contiguous.Class ( src/Data/Primitive/Contiguous/Class.hs, /home/chessai/haskell/contiguous/dist-newstyle/build/x86_64-linux/ghc-9.4.4/contiguous-0.6.3.0/build/Data/Primitive/Contiguous/Class.o, /home/chessai/haskell/contiguous/dist-newstyle/build/x86_64-linux/ghc-9.4.4/contiguous-0.6.3.0/build/Data/Primitive/Contiguous/Class.dyn_o )

src/Data/Primitive/Contiguous/Class.hs:214:21: warning: [-Wtype-equality-requires-operators]
    The use of ‘~’ without TypeOperators
    will become an error in a future GHC release.
    Suggested fix: Perhaps you intended to use TypeOperators
    |
214 |        ( Sliced arr ~ Slice arr, ContiguousU arr
    |                     ^

src/Data/Primitive/Contiguous/Class.hs:230:28: warning: [-Wtype-equality-requires-operators]
    The use of ‘~’ without TypeOperators
    will become an error in a future GHC release.
    Suggested fix: Perhaps you intended to use TypeOperators
    |
230 |        ( MutableSliced arr ~ MutableSlice arr, ContiguousU arr
    |                            ^

src/Data/Primitive/Contiguous/Class.hs:253:28: warning: [-Wtype-equality-requires-operators]
    The use of ‘~’ without TypeOperators
    will become an error in a future GHC release.
    Suggested fix: Perhaps you intended to use TypeOperators
    |
253 |        ( MutableSliced arr ~ MutableSlice arr, ContiguousU arr
    |                            ^

src/Data/Primitive/Contiguous/Class.hs:293:21: warning: [-Wtype-equality-requires-operators]
    The use of ‘~’ without TypeOperators
    will become an error in a future GHC release.
    Suggested fix: Perhaps you intended to use TypeOperators
    |
293 |        ( Sliced arr ~ Slice arr, ContiguousU arr
    |                     ^

src/Data/Primitive/Contiguous/Class.hs:318:20: warning: [-Wtype-equality-requires-operators]
    The use of ‘~’ without TypeOperators
    will become an error in a future GHC release.
    Suggested fix: Perhaps you intended to use TypeOperators
    |
318 |       ( Sliced arr ~ Slice arr, ContiguousU arr
    |                    ^

src/Data/Primitive/Contiguous/Class.hs:344:28: warning: [-Wtype-equality-requires-operators]
    The use of ‘~’ without TypeOperators
    will become an error in a future GHC release.
    Suggested fix: Perhaps you intended to use TypeOperators
    |
344 |        ( MutableSliced arr ~ MutableSlice arr, ContiguousU arr
    |                            ^
[3 of 3] Compiling Data.Primitive.Contiguous ( src/Data/Primitive/Contiguous.hs, /home/chessai/haskell/contiguous/dist-newstyle/build/x86_64-linux/ghc-9.4.4/contiguous-0.6.3.0/build/Data/Primitive/Contiguous.o, /home/chessai/haskell/contiguous/dist-newstyle/build/x86_64-linux/ghc-9.4.4/contiguous-0.6.3.0/build/Data/Primitive/Contiguous.dyn_o )
```