### PR TITLE
Implement Contiguous and ContiguousU for SmallUnliftedArray

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,8 @@
 packages: .
 tests: True
+
+
+source-repository-package
+    type: git
+    location: git@github.com:Qqwy/haskell-primitive-unlifted.git
+    tag: 784fc78815a695db6db69c729a364663e4f0afe2

--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,2 @@
 packages: .
 tests: True
-
-
-source-repository-package
-    type: git
-    location: git@github.com:Qqwy/haskell-primitive-unlifted.git
-    tag: 784fc78815a695db6db69c729a364663e4f0afe2

--- a/contiguous.cabal
+++ b/contiguous.cabal
@@ -39,7 +39,7 @@ library
     , base                >=4.14    && <5
     , deepseq             >=1.4
     , primitive           >=0.9     && <0.10
-    , primitive-unlifted  >=2.1
+    , primitive-unlifted  >=2.2
     , run-st              >=0.1.3.2
 
   ghc-options:     -O2

--- a/src/Data/Primitive/Contiguous.hs
+++ b/src/Data/Primitive/Contiguous.hs
@@ -270,11 +270,14 @@ module Data.Primitive.Contiguous
   , MutablePrimArray
   , UnliftedArray
   , MutableUnliftedArray
+  , SmallUnliftedArray
+  , SmallMutableUnliftedArray
   ) where
 
 import Control.Monad.Primitive
 import Data.Primitive
 import Data.Primitive.Unlifted.Array
+import Data.Primitive.Unlifted.SmallArray
 import Prelude hiding (Foldable (..), all, any, filter, map, mapM, mapM_, read, replicate, reverse, scanl, sequence, sequence_, traverse, zip, zipWith, (<$))
 
 import Control.Monad (when)

--- a/src/Data/Primitive/Contiguous/Class.hs
+++ b/src/Data/Primitive/Contiguous/Class.hs
@@ -894,7 +894,7 @@ instance Contiguous (SmallUnliftedArray_ unlifted_a) where
   type Sliced (SmallUnliftedArray_ unlifted_a) = Slice (SmallUnliftedArray_ unlifted_a)
   type MutableSliced (SmallUnliftedArray_ unlifted_a) = MutableSlice (SmallUnliftedArray_ unlifted_a)
   {-# INLINE new #-}
-  new n = newSmallUnliftedArray n errorThunk
+  new n = unsafeNewSmallUnliftedArray n
   {-# INLINE empty #-}
   empty = emptySmallUnliftedArray
   {-# INLINE index #-}


### PR DESCRIPTION
These were still missing, and I have need for them 😊.


NOTE: This requires some fixes in `primitive-unlifted`,
c.f. https://github.com/haskell-primitive/primitive-unlifted/issues/43 and PR https://github.com/haskell-primitive/primitive-unlifted/pull/44

- [x] Contiguous implementation for SmallUnliftedArray
- [x] ContiguousU implementation for SmallUnliftedArray
- [x] Resize helper in `Shim` for `SmallMutableUnliftedArray`.
- [x] A temporary implementation of `runSmallUnliftedArrayST`; also see https://github.com/byteverse/run-st/issues/5 and PR https://github.com/byteverse/run-st/pull/6
- [x] Removal of the `cabal.project` changes that temporarily points to a fork with the fixes to `primitive-unlifted` applied.
